### PR TITLE
Cleanup sftp image and drop 200+MB from image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,20 @@
-FROM ubuntu:14.04
+FROM alpine:latest
 MAINTAINER ATSD Developers <dev-atsd@axibase.com>
 ENV ftpuser="ftp-user"
 
-RUN apt-get update && apt-get upgrade && \
-    apt-get install -y vsftpd openssh-server curl && \
-    groupadd ftpaccess && \
+RUN apk add --no-cache openssh && \
+    addgroup ftpaccess && \
     mkdir -p /home/${ftpuser}/ftp && \
-    mkdir -p /var/run/sshd && \
-    useradd -m ${ftpuser} -g ftpaccess -s /usr/sbin/nologin && \
-    chown ${ftpuser}:ftpaccess /home/${ftpuser}/ftp && \
-    echo "/usr/sbin/nologin" >> /etc/shells
+    adduser -D -G ftpaccess -s /usr/sbin/nologin ${ftpuser} && \
+    chown root:root /home/${ftpuser} && \
+    chown ${ftpuser}:ftpaccess /home/${ftpuser}/ftp
 
-RUN curl -L -o /opt/entrypoint.sh https://raw.githubusercontent.com/axibase/dockers/sftp/entrypoint.sh && \
-    chmod +x /opt/entrypoint.sh && \
-    curl -L -o /etc/ssh/sshd_config https://raw.githubusercontent.com/axibase/dockers/sftp/sshd_config
-    
+ADD entrypoint.sh /opt/entrypoint.sh
+ADD sshd_config /etc/ssh/sshd_config 
 
 WORKDIR /home/${ftpuser}
 
 #sftp
 EXPOSE 22
 VOLUME ["/home/${ftpuser}"]
-ENTRYPOINT ["/opt/entrypoint.sh"]
- 
+ENTRYPOINT ["/bin/sh", "/opt/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 password="$RANDOM-$RANDOM-$RANDOM"
 echo $password | tee /opt/$ftpuser-password
 
 echo "$ftpuser:$password" | chpasswd
 
-/usr/sbin/sshd -D
+ssh-keygen -q -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
+ssh-keygen -q -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa
+ssh-keygen -q -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
+ssh-keygen -q -f /etc/ssh/ssh_host_ed25519_key -N '' -t ed25519
 
+/usr/sbin/sshd -D

--- a/sshd_config
+++ b/sshd_config
@@ -25,7 +25,7 @@ ChallengeResponseAuthentication no
 
 X11DisplayOffset 10
 PrintMotd no
-PrintLastLog yes
+#PrintLastLog yes
 TCPKeepAlive yes
 AcceptEnv LANG LC_*
 


### PR DESCRIPTION
Using ubuntu is easy but alpine provides significant savings 200+mb

pulled curl and vsftpd from apt-get ( fyi, you don't need to `RUN curl` when you can `ADD url dest` in the dockerfile ).