### PR TITLE
Add combined variable for paths

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,11 @@ ATSD_COLLECTOR_USER_PASSWORD=collector
 COLLECTOR_USER_NAME=axibase
 COLLECTOR_USER_PASSWORD=axibase
 
+if [ -n "$IMPORT_PATHS" ]; then
+    ATSD_IMPORT_PATH=$(echo "$IMPORT_PATHS" | cut -d ";" -f 1)
+    COLLECTOR_IMPORT_PATH=$(echo "$IMPORT_PATHS" | cut -d ";" -f 2)
+fi
+
 function start_atsd {
     function set_tz {
         # set custom timezone


### PR DESCRIPTION
Additional variable for specifying files to import `IMPORT_PATHS="atsd_path;collector_path1,collector_path2,..."`
Example

```
docker run -d -p 8443:8443 -p 9443:9443 -p 8081:8081 \
	--name=atsd-sandbox \
	--volume /var/run/docker.sock:/var/run/docker.sock \
	--volume /home/axibase/atsd-marathon-xml.zip:/marathon.zip \
	--volume /home/axibase/jobs.xml:/jobs.xml \
	--volume /home/axibase/jobs-2.xml:/jobs-2.xml \
	--env IMPORT_PATHS="/marathon.zip;/jobs.xml,/jobs-2.xml" \
	axibase/atsd-sandbox:latest
```