### PR TITLE
GH-89: Populate settings option

### DIFF
--- a/entrycleanup.sh
+++ b/entrycleanup.sh
@@ -12,7 +12,7 @@ function cleanup_apt_files() {
 function create_hbase_tables() {
   echo "Creating Hbase tables"
   #Do not import any artifacts on this step, as settings and profile defined only in entrypoint stage
-  JAVA_PROPERTIES=\"-Dsettings= \$JAVA_PROPERTIES\"
+  JAVA_PROPERTIES="-Dsettings= $JAVA_PROPERTIES"
   /bin/bash ${DISTR_HOME}/bin/atsd-tsd.sh start
   /bin/bash ${DISTR_HOME}/bin/stop-atsd.sh -f
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,11 @@ if [ -n "$profile" ]; then
   echo "[ATSD] Database profile set to $profile" | tee -a $LOGFILESTART
   echo "export JAVA_PROPERTIES=\"-Dprofile=$profile \$JAVA_PROPERTIES\"" >> /opt/atsd/conf/atsd-env.sh
 fi;
+# use -v check for empty settings case
+if [[ -v settings ]]; then
+  echo "[ATSD] Database is used following settings: $settings" | tee -a $LOGFILESTART
+  echo "export JAVA_PROPERTIES=\"-Dsettings=$settings \$JAVA_PROPERTIES\"" >> /opt/atsd/conf/atsd-env.sh
+fi;
 
 bash /opt/atsd/bin/atsd-tsd.sh start
 


### PR DESCRIPTION
Closes #89 

Add `settings` env variable support - from axibase/tsd#1279

```bash
docker run -p 8088:8088 --env profile=FINANCE --env settings= axibase/atsd
```